### PR TITLE
feat(partner-dashboard): add org_id-based partner dashboard with Supa…

### DIFF
--- a/lib/partnerAnalytics.test.ts
+++ b/lib/partnerAnalytics.test.ts
@@ -1,0 +1,64 @@
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { fetchPartnerAnalytics } from './partnerAnalytics';
+
+describe('fetchPartnerAnalytics', () => {
+  let consoleWarnSpy: any;
+
+  beforeEach(() => {
+    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('returns missing_org_id when org_id is empty', async () => {
+    const mockClient = { from: vi.fn() };
+    const res = await fetchPartnerAnalytics(mockClient as any, '');
+    expect(res.error).toBe('missing_org_id');
+    expect(res.data).toEqual([]);
+  });
+
+  it('returns no_client when supabase client is null', async () => {
+    const res = await fetchPartnerAnalytics(null as any, 'org-123');
+    expect(res.error).toBe('no_client');
+    expect(res.data).toEqual([]);
+  });
+
+  it('returns data array on successful fetch', async () => {
+    const data = [
+      { stage: 'seed', sector: 'fintech', composite_target: 1000, created_at: '2025-01-01T00:00:00Z' },
+      { stage: 'pre-seed', sector: 'saas', composite_target: 2000, created_at: '2025-01-02T00:00:00Z' },
+    ];
+
+    const orderMock = vi.fn().mockResolvedValue({ data, error: null });
+    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
+    const eqMock = vi.fn().mockReturnValue({ select: selectMock });
+    const fromMock = vi.fn().mockReturnValue({ eq: eqMock });
+
+    const supabaseMock = { from: fromMock };
+
+    const res = await fetchPartnerAnalytics(supabaseMock as any, 'org-123');
+
+    expect(fromMock).toHaveBeenCalledWith('analytics_evaluations');
+    expect(eqMock).toHaveBeenCalledWith('org_id', 'org-123');
+    expect(selectMock).toHaveBeenCalledWith('stage,sector,composite_target,created_at');
+    expect(orderMock).toHaveBeenCalledWith('created_at', { ascending: false });
+
+    expect(res.data.length).toBe(2);
+    expect(res.error).toBeUndefined();
+  });
+
+  it('logs and returns empty data when supabase returns error', async () => {
+    const orderMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } });
+    const selectMock = vi.fn().mockReturnValue({ order: orderMock });
+    const eqMock = vi.fn().mockReturnValue({ select: selectMock });
+    const fromMock = vi.fn().mockReturnValue({ eq: eqMock });
+    const supabaseMock = { from: fromMock };
+
+    const res = await fetchPartnerAnalytics(supabaseMock as any, 'org-123');
+    expect(consoleWarnSpy).toHaveBeenCalled();
+    expect(res.data).toEqual([]);
+    expect(res.error).toBe('boom');
+  });
+});

--- a/lib/partnerAnalytics.ts
+++ b/lib/partnerAnalytics.ts
@@ -1,0 +1,36 @@
+// Helper to fetch partner-specific analytics from staging Supabase
+// TODO: Production’da RLS aktif olacak, backend route üzerinden proxy'lenecek.
+export async function fetchPartnerAnalytics(
+  supabase: any,
+  org_id: string
+): Promise<{ data: any[]; error?: string }> {
+  try {
+    if (!org_id) {
+      return { data: [], error: 'missing_org_id' };
+    }
+
+    if (!supabase) {
+      return { data: [], error: 'no_client' };
+    }
+
+    const table = 'analytics_evaluations';
+
+    // build chain: from(...).eq(...).select(...).order(...)
+    // select columns: stage, sector, composite_target, created_at
+    const res = await supabase
+      .from(table)
+      .eq('org_id', org_id)
+      .select('stage,sector,composite_target,created_at')
+      .order('created_at', { ascending: false });
+
+    if (res && res.error) {
+      console.warn('fetchPartnerAnalytics error', res.error);
+      return { data: [], error: res.error?.message || 'fetch_error' };
+    }
+
+    return { data: res.data || [], error: undefined };
+  } catch (err: any) {
+    console.warn('fetchPartnerAnalytics exception', err?.message || err);
+    return { data: [], error: 'exception' };
+  }
+}

--- a/pages/partner/dashboard.tsx
+++ b/pages/partner/dashboard.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { getSupabaseClient } from '../../lib/supabaseClient';
+import { fetchPartnerAnalytics } from '../../lib/partnerAnalytics';
+
+export default function PartnerDashboardPage() {
+  const router = useRouter();
+  const q = router.query;
+  const queryOrg = typeof q.org_id === 'string' ? q.org_id : (Array.isArray(q.org_id) ? String(q.org_id[0]) : undefined);
+
+  const [orgId, setOrgId] = useState<string | null>(null);
+  const [data, setData] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  useEffect(() => {
+    // prefer query param, fallback to localStorage (mock)
+    if (queryOrg) {
+      setOrgId(queryOrg);
+    } else if (typeof window !== 'undefined') {
+      const fromLs = localStorage.getItem('org_id');
+      setOrgId(fromLs || null);
+    }
+  }, [queryOrg]);
+
+  useEffect(() => {
+    let mounted = true;
+    async function load() {
+      setLoading(true);
+      setErrorMsg(null);
+
+      if (!orgId) {
+        setErrorMsg('Org ID bulunamadı');
+        setLoading(false);
+        return;
+      }
+
+      const supabase = getSupabaseClient();
+      if (!supabase) {
+        setErrorMsg('Veri alınamadı (staging offline)');
+        setLoading(false);
+        return;
+      }
+
+      const res = await fetchPartnerAnalytics(supabase, orgId);
+      if (!mounted) return;
+
+      if (res.error) {
+        setErrorMsg('Veri alınamadı (staging offline)');
+        setData([]);
+      } else {
+        setData(res.data || []);
+      }
+
+      setLoading(false);
+    }
+
+    load();
+    return () => {
+      mounted = false;
+    };
+  }, [orgId]);
+
+  return (
+    <div className="min-h-screen p-4 bg-gray-50 flex items-start justify-center">
+      <div className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm max-w-3xl w-full mx-auto flex flex-col gap-4">
+        <h1 className="text-lg font-semibold text-gray-900">Partner Dashboard</h1>
+
+        {/* TODO: RLS prod ortamında aktif olacak (org_id → user token) */}
+        {/* TODO: Admin dashboard aggregate veriyi bu tablodan okuyacak */}
+        {/* TODO: Partner auth eklendiğinde org_id router parametresinden değil token'dan alınacak */}
+        {/* TODO: Staging Supabase dışında hiçbir ortamda bu query çalışmamalı */}
+
+        {loading && <div className="text-sm text-gray-500">Veri yükleniyor...</div>}
+
+        {errorMsg && (
+          <div className="bg-red-50 text-red-700 border border-red-200 rounded-md p-2 text-sm">{errorMsg}</div>
+        )}
+
+        {!loading && !errorMsg && data.length === 0 && (
+          <div className="text-sm text-gray-600">Henüz analiz veriniz yok.</div>
+        )}
+
+        {!loading && !errorMsg && data.length > 0 && (
+          <table className="w-full text-sm border-collapse border border-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="border px-2 py-1 text-left">Stage</th>
+                <th className="border px-2 py-1 text-left">Sector</th>
+                <th className="border px-2 py-1 text-left">Target (USD)</th>
+                <th className="border px-2 py-1 text-left">Date</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.map((row, i) => (
+                <tr key={i}>
+                  <td className="border px-2 py-1">{row.stage}</td>
+                  <td className="border px-2 py-1">{row.sector}</td>
+                  <td className="border px-2 py-1">{row.composite_target?.toLocaleString?.() ?? row.composite_target}</td>
+                  <td className="border px-2 py-1">{new Date(row.created_at).toLocaleDateString()}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/tests/pages/partner.dashboard.test.tsx
+++ b/tests/pages/partner.dashboard.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { vi, describe, it, beforeEach, expect } from 'vitest';
+
+// Mock next/router to provide query org_id
+vi.mock('next/router', () => ({
+  useRouter: () => ({ query: { org_id: 'org-123' } }),
+}));
+
+// Mock getSupabaseClient to return a fake client
+vi.mock('../../lib/supabaseClient', () => ({
+  getSupabaseClient: () => ({ /* fake client */ }),
+}));
+
+// Mock fetchPartnerAnalytics to return two rows
+const fakeData = [
+  { stage: 'seed', sector: 'fintech', composite_target: 1000, created_at: '2025-01-01T00:00:00Z' },
+  { stage: 'pre-seed', sector: 'saas', composite_target: 2000, created_at: '2025-01-02T00:00:00Z' },
+];
+vi.mock('../../lib/partnerAnalytics', () => ({
+  fetchPartnerAnalytics: () => Promise.resolve({ data: fakeData }),
+}));
+
+describe('Partner dashboard page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders table headers and rows when data present', async () => {
+    const Page = (await import('../../../pages/partner/dashboard')).default;
+    render(<Page />);
+
+    expect(await screen.findByText(/Stage/)).toBeTruthy();
+    expect(await screen.findByText(/Target \(USD\)/)).toBeTruthy();
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole('row');
+      // there is header row + 2 data rows
+      expect(rows.length).toBeGreaterThanOrEqual(3);
+    });
+  });
+
+  it('shows Org ID bulunamadı when org_id missing', async () => {
+    // Re-mock router with no org_id
+    vi.doMock('next/router', () => ({ useRouter: () => ({ query: {} }) }));
+    const Page = (await import('../../../pages/partner/dashboard')).default;
+    render(<Page />);
+
+    expect(await screen.findByText(/Org ID bulunamadı/)).toBeTruthy();
+  });
+
+  it('shows staging offline message when supabase client is null', async () => {
+    // Mock getSupabaseClient to return null
+    vi.doMock('../../lib/supabaseClient', () => ({ getSupabaseClient: () => null }));
+    // Ensure router returns org_id
+    vi.doMock('next/router', () => ({ useRouter: () => ({ query: { org_id: 'org-123' } }) }));
+
+    const Page = (await import('../../../pages/partner/dashboard')).default;
+    render(<Page />);
+
+    expect(await screen.findByText(/Veri alınamadı \(staging offline\)/)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Partner organizasyonlarının verilerini staging Supabase’teki analytics_evaluations tablosundan çeken bir helper (partnerAnalytics.ts) ve buna ait unit testler, ayrıca /partner/dashboard sayfası (dashboard.tsx) ile sayfa testleri eklendi. UI eksik org_id veya staging Supabase yokluğunda kullanıcıyı bilgilendirir; production davranışı (RLS, backend proxy) TODO olarak bırakıldı. Bu değişiklikler staging/preview içindir ve production anahtarlarını kullanmaz — production'u bozmaz.